### PR TITLE
Add process.env.PORT for use with heroku deployment

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ var db = require('../database-mysql/models.js');
 
 var app = express();
 
+var PORT = process.env.PORT || 5000;
 
 app.use(express.static(__dirname + '/../client/dist'));
 app.use(bodyParser.json());
@@ -120,7 +121,7 @@ app.post('/rate', function (req, res) {
     }
   })
 })
-app.listen(5000, function() {
-  console.log('listening on port 5000!');
+app.listen(PORT, function() {
+  console.log('listening on port ' + PORT + '!');
 });
 


### PR DESCRIPTION
Heroku designates its own port for the server so I added process.env as an option for the PORT to run on.